### PR TITLE
Fix du retour au panier pendant le processus de paiement

### DIFF
--- a/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
+++ b/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
@@ -70,7 +70,7 @@ class Sirateck_Cashway_Block_Form_Cashway extends Mage_Payment_Block_Form
      */
     public function canWork()
     {
-        $cw_res = $this->getEvaluateTransaction();
+        $cw_res = $this->getEvaluateTransaction()->_data;
 
         if (array_key_exists('errors', $cw_res)) {
             $errorMsg = "";
@@ -80,6 +80,9 @@ class Sirateck_Cashway_Block_Form_Cashway extends Mage_Payment_Block_Form
                     break;
                 case 'unavailable':
                     $errorMsg = '<!-- CW debug: API unavailable -->';
+                    break;
+                case 'no_auth':
+                    $errorMsg = '<!-- CW debug: not configured -->';
                     break;
                 default:
                     $errorMsg = '<!-- CW debug: unknown -->';

--- a/src/magento/app/code/community/Sirateck/Cashway/Model/Api/Request.php
+++ b/src/magento/app/code/community/Sirateck/Cashway/Model/Api/Request.php
@@ -195,6 +195,8 @@ class Sirateck_Cashway_Model_Api_Request extends Varien_Object
         /* @var $response Zend_Http_Response */
         $response = $this->getClient()->request($method);
 
+        return json_decode($response->getBody(), true);
+
         if ($response->isSuccessful()) {
             return json_decode($response->getBody(), true);
         } else {

--- a/src/magento/app/code/community/Sirateck/Cashway/Model/Method/Cashway.php
+++ b/src/magento/app/code/community/Sirateck/Cashway/Model/Method/Cashway.php
@@ -116,7 +116,7 @@ class Sirateck_Cashway_Model_Method_Cashway extends Mage_Payment_Model_Method_Ab
 
     public function getModuleAgent()
     {
-        if (!property_exists($this, $cashway_agent)) {
+        if (!property_exists($this, 'cashway_agent')) {
             $this->cashway_agent = sprintf(
                 'CashWayModule/%s Magento/%s PHP/%s %s',
                 Mage::getConfig()->getModuleConfig("Sirateck_Cashway")->version,


### PR DESCRIPTION
Lors du processus de paiement, l'utilisateur était redirigé vers son panier juste avant de choisir un moyen de paiement.

* Le tableau contenant les données de retour de la requête evaluateTransaction a été extrait de l'objet qui le contenait, ainsi la méthode vérifiant que le module est opérationnel peut se comporter normalement.

* Correction d'un warning sur une variable non définie (cashway_agent).