### PR TITLE
Permettre les tests avec Poltergeist

### DIFF
--- a/src/prestashop/Readme.md
+++ b/src/prestashop/Readme.md
@@ -20,6 +20,15 @@ This module depends on APIs provided by [CashWay](https://www.cashway.fr/):
  * Tests in `tests/php` are static tests to be run locally (`make test-CWD` or `make test-HEAD`).
  * Tests in `tests/spec` are to be run against a live PrestaShop test instance.
 
+In order to select a specific driver for the tests, it is necessary to modify the environment variable DRIVER :
+
+```shell
+$ DRIVER=selenium
+or
+$ DRIVER=poltergeist
+or
+$ DRIVER=webkit
+```
 
 ## Building a release
 

--- a/src/prestashop/tests/spec/add_new_account.rb
+++ b/src/prestashop/tests/spec/add_new_account.rb
@@ -18,6 +18,8 @@ describe "Add a new customer user" do
       find('#login_form').fill_in('passwd', with: ENV['CUSTOMER_PASSWD'])
 
       find(:xpath, '//button[@id="SubmitLogin"]').click
+      expect(page).to have_selector ".info-account"
+      first('i.icon-building').click
     else
       puts "Registers account"
       fill_in 'customer_firstname', with: ENV['CUSTOMER_FIRSTNAME']
@@ -25,18 +27,22 @@ describe "Add a new customer user" do
       fill_in 'passwd', with: ENV['CUSTOMER_PASSWD']
 
       find(:xpath, '//button[@name="submitAccount"]').click
+
+      expect(page).to have_selector "i.icon-building"
+      find(:xpath, '//a[@title="Add my first address"]').click
     end
   end
 
   it "registers an address" do
-    find(:xpath, '//a[@title="Add my first address"]').click
-    fill_in 'address1', with: ENV['CUSTOMER_ADRESS']
-    fill_in 'city', with: ENV['CUSTOMER_CITY']
-    fill_in 'postcode', with: ENV['CUSTOMER_ZIPCODE']
-    fill_in 'address1', with: ENV['CUSTOMER_ADRESS']
-    fill_in 'phone_mobile', with: ENV['CUSTOMER_PHONE']
-
-    find(:xpath, '//select[@id="id_country"]/option[@value="8"]').click
-    find(:xpath, '//button[@id="submitAddress"]').click
+    if has_selector?('li.address_update')
+      puts "There is an address already"
+    else
+      fill_in 'address1', with: ENV['CUSTOMER_ADRESS']
+      fill_in 'city', with: ENV['CUSTOMER_CITY']
+      fill_in 'postcode', with: ENV['CUSTOMER_ZIPCODE']
+      fill_in 'address1', with: ENV['CUSTOMER_ADRESS']
+      fill_in 'phone_mobile', with: ENV['CUSTOMER_PHONE']
+      find(:xpath, '//button[@id="submitAddress"]').click
+    end
   end
 end

--- a/src/prestashop/tests/spec/add_test_products.rb
+++ b/src/prestashop/tests/spec/add_test_products.rb
@@ -19,6 +19,7 @@ describe "Adds test products" do
   [50, 250, 2500].each do |price|
     describe "adds #{price} € product" do
       it "open new product page" do
+        find('li#maintab-AdminCatalog').hover
         find('li#subtab-AdminProducts').click
         expect(page).to have_selector("#form-product")
         click_link_or_button 'Add new product'

--- a/src/prestashop/tests/spec/client_use.rb
+++ b/src/prestashop/tests/spec/client_use.rb
@@ -84,10 +84,10 @@ end
         $barcode = find('#cashway-barcode-label').text.gsub(' ', '')
 
         if 250 == price
-          mail = URI.parse(page.find('a[id = "cashway-kyc-email"]')['href'])
+          mail = URI.parse(URI.encode(page.find('a[id = "cashway-kyc-email"]')['href']))
           expect(mail.to).to eq 'validation@cashway.fr'
 
-          form = URI.parse(page.find('a[id = "cashway-kyc-form"]')['href'])
+          form = URI.parse(URI.encode(page.find('a[id = "cashway-kyc-form"]')['href']))
           expect(form.scheme).to eq 'https'
           expect(form.host.end_with?('.cashway.fr')).to be true
         end

--- a/src/prestashop/tests/spec/config_base.rb
+++ b/src/prestashop/tests/spec/config_base.rb
@@ -6,6 +6,8 @@ describe "PrestaShop basic setup" do
     session.visit '/install'
     if Capybara.current_driver === :poltergeist
       find('#langList').find('option[value="en"]').trigger('click')
+    elsif Capybara.current_driver === :webkit
+      #
     else
       find('#langList').find('option[value="en"]').click
     end

--- a/src/prestashop/tests/spec/config_base.rb
+++ b/src/prestashop/tests/spec/config_base.rb
@@ -4,7 +4,11 @@ describe "PrestaShop basic setup" do
 
   it "loads installation page & select English" do
     session.visit '/install'
-    find('#langList').find('option[value="en"]').click
+    if Capybara.current_driver === :poltergeist
+      find('#langList').find('option[value="en"]').trigger('click')
+    else
+      find('#langList').find('option[value="en"]').click
+    end
     find('#btNext').click
   end
 

--- a/src/prestashop/tests/spec/config_base.rb
+++ b/src/prestashop/tests/spec/config_base.rb
@@ -40,7 +40,8 @@ describe "PrestaShop basic setup" do
   end
 
   it "succeeds installation" do
-    expect(page).to have_content 'finished'
+    print "Veuillez appuyer sur une touche pour continuer le processus d'installation..."
+    $stdin.gets
     find('#install_process_success', visible: true)
   end
 end

--- a/src/prestashop/tests/spec/config_base.rb
+++ b/src/prestashop/tests/spec/config_base.rb
@@ -40,9 +40,7 @@ describe "PrestaShop basic setup" do
   end
 
   it "succeeds installation" do
-    print "Veuillez appuyer sur une touche pour continuer le processus d'installation..."
-    $stdin.gets
-    #sleep 70
+    expect(page).to have_content 'finished'
     find('#install_process_success', visible: true)
   end
 end

--- a/src/prestashop/tests/spec/init_admin.rb
+++ b/src/prestashop/tests/spec/init_admin.rb
@@ -6,14 +6,19 @@ describe "Admin post configuration" do
     session.visit '/admin'
     session.visit ENV['ADMIN_PATH'] if page.has_content?('NOT AVAILABLE')
 
+    expect(page).to have_selector '#shop-img'
     fill_in 'email', with: ENV['ADMIN_EMAIL']
     fill_in 'passwd', with: ENV['ADMIN_PASSWD']
     find(:xpath, '//button[@class="btn btn-primary btn-lg btn-block ladda-button"]').click
   end
 
   it "sets filter country" do
+    find('li#maintab-AdminParentLocalization').click
+    expect(page).to have_content 'Localization pack you want to import'
+    page.save_screenshot('lib/subtab-AdminCountries.png', :full => true);
     find('li#maintab-AdminParentLocalization').hover
-    find(:xpath, '//li[@id="subtab-AdminCountries"]/a').click
+    find('li#subtab-AdminCountries').click
+    page.save_screenshot('lib/subtab-AdminCountries-displayed.png')
     fill_in 'countryFilter_b!name', with: ENV['SERVER_COUNTRY']
     find(:xpath, '//button[@id="submitFilterButtoncountry"]').click
 

--- a/src/prestashop/tests/spec/init_admin.rb
+++ b/src/prestashop/tests/spec/init_admin.rb
@@ -15,10 +15,8 @@ describe "Admin post configuration" do
   it "sets filter country" do
     find('li#maintab-AdminParentLocalization').click
     expect(page).to have_content 'Localization pack you want to import'
-    page.save_screenshot('lib/subtab-AdminCountries.png', :full => true);
     find('li#maintab-AdminParentLocalization').hover
     find('li#subtab-AdminCountries').click
-    page.save_screenshot('lib/subtab-AdminCountries-displayed.png')
     fill_in 'countryFilter_b!name', with: ENV['SERVER_COUNTRY']
     find(:xpath, '//button[@id="submitFilterButtoncountry"]').click
 

--- a/src/prestashop/tests/spec/spec_helper.rb
+++ b/src/prestashop/tests/spec/spec_helper.rb
@@ -67,6 +67,7 @@ end
 
 if $driver == :poltergeist
   page.driver.add_header('Accept-Language', 'en', permanent: true)
+  page.driver.browser.js_errors = false
 end
 
 # If Selenium

--- a/src/prestashop/tests/spec/spec_helper.rb
+++ b/src/prestashop/tests/spec/spec_helper.rb
@@ -12,7 +12,7 @@ def define_driver (driver_name)
   case driver_name
   when 'selenium'
     puts "The selected driver is Selenium."
-    $driver = :selenium
+    $driver = :selenium_en
   when 'webkit'
     puts "The selected driver is Webkit."
     $driver = :webkit

--- a/src/prestashop/tests/spec/spec_helper.rb
+++ b/src/prestashop/tests/spec/spec_helper.rb
@@ -52,7 +52,7 @@ Capybara.configure do |config|
   config.run_server = false
   config.always_include_port = true
   config.app_host = ENV['TEST_SERVER']
-  config.default_max_wait_time = 60
+  config.default_max_wait_time = 80
   config.ignore_hidden_elements = true
   # wait_on_first_by_default
 end

--- a/src/prestashop/tests/spec/spec_helper.rb
+++ b/src/prestashop/tests/spec/spec_helper.rb
@@ -8,6 +8,22 @@ require 'capybara/poltergeist'
 require 'awesome_print'
 require 'uri'
 
+def define_driver (driver_name)
+  case driver_name
+  when 'selenium'
+    puts "The selected driver is Selenium."
+    $driver = :selenium
+  when 'webkit'
+    puts "The selected driver is Webkit."
+    $driver = :webkit
+  else
+    puts "The default driver is Poltergeist"
+    $driver = :poltergeist
+  end
+end
+
+define_driver ENV['DRIVER']
+
 RSpec.configure do |config|
   config.expect_with :rspec do |expectations|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
@@ -39,9 +55,6 @@ Capybara.register_driver :selenium_en do |app|
   Capybara::Selenium::Driver.new app, browser: :firefox, profile: profile
 end
 
-$driver = :selenium_en
-#$driver = :webkit
-#$driver = :poltergeist
 Capybara::Webkit.configure do |config|
   config.block_unknown_urls
   config.skip_image_loading

--- a/src/prestashop/tests/spec/spec_helper.rb
+++ b/src/prestashop/tests/spec/spec_helper.rb
@@ -52,7 +52,7 @@ Capybara.configure do |config|
   config.run_server = false
   config.always_include_port = true
   config.app_host = ENV['TEST_SERVER']
-  config.default_max_wait_time = 80
+  config.default_max_wait_time = 15
   config.ignore_hidden_elements = true
   # wait_on_first_by_default
 end

--- a/src/prestashop/tests/spec/spec_helper.rb
+++ b/src/prestashop/tests/spec/spec_helper.rb
@@ -52,7 +52,7 @@ Capybara.configure do |config|
   config.run_server = false
   config.always_include_port = true
   config.app_host = ENV['TEST_SERVER']
-  config.default_max_wait_time = 15
+  config.default_max_wait_time = 60
   config.ignore_hidden_elements = true
   # wait_on_first_by_default
 end


### PR DESCRIPTION
Poltergeist permet d'effectuer des tests headless, dans passer par un navigateur ce qui permet notamment d'augmenter la vitesse d'exécution des tests.