### PR TITLE
Ajout du contrôle du montant sur le plugin Magento

### DIFF
--- a/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
+++ b/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
@@ -66,7 +66,7 @@ class Sirateck_Cashway_Block_Form_Cashway extends Mage_Payment_Block_Form
 
     public function isExcessiveAmount($amount)
     {
-        return $amount <= 1000;
+        return $amount > 1000;
     }
 
     /**

--- a/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
+++ b/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
@@ -64,6 +64,11 @@ class Sirateck_Cashway_Block_Form_Cashway extends Mage_Payment_Block_Form
         return $this->_evaluateTransaction;
     }
 
+    public function checkOrderAmount($amount)
+    {
+        return $amount <= 1000;
+    }
+
     /**
      * Check if cashway service is available with evaluateTransaction api endpoint
      * @return boolean
@@ -77,9 +82,9 @@ class Sirateck_Cashway_Block_Form_Cashway extends Mage_Payment_Block_Form
     	catch (Exception $e){
     		$this->_getMethodinstance()->debugData($e->getMessage());
     	}
-		
+
     	return false;
-       
+
     }
 
     /**

--- a/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
+++ b/src/magento/app/code/community/Sirateck/Cashway/Block/Form/Cashway.php
@@ -64,7 +64,7 @@ class Sirateck_Cashway_Block_Form_Cashway extends Mage_Payment_Block_Form
         return $this->_evaluateTransaction;
     }
 
-    public function checkOrderAmount($amount)
+    public function isExcessiveAmount($amount)
     {
         return $amount <= 1000;
     }

--- a/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
+++ b/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
@@ -33,7 +33,7 @@ $_code=$this->getMethodCode();
 //]]>
 </script>
 <?php elseif(!$this->checkOrderAmount($this->helper('checkout/cart')->getQuote()->getGrandTotal())):?>
-<p><?php echo $this->__("Your order's amount exceeds the maximum amount for the CASHWAY payment method.");?> (<a href="https://help.cashway.fr/cgu/">More informations</a>)</p>
+<p><?php echo $this->__("Your order's amount exceeds the maximum amount for the CASHWAY payment method. (<a href='https://help.cashway.fr/cgu/'>More informations</a>)");?></p>
 <script type="text/javascript">
   $('p_method_cashway').disable();
 </script>

--- a/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
+++ b/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
@@ -32,7 +32,7 @@ $_code=$this->getMethodCode();
  		$('p_method_cashway').disable();
 //]]>
 </script>
-<?php elseif(!$this->isExcessiveAmount($this->helper('checkout/cart')->getQuote()->getGrandTotal())):?>
+<?php elseif($this->isExcessiveAmount($this->helper('checkout/cart')->getQuote()->getGrandTotal())):?>
 <p><?php echo $this->__("Your order's amount exceeds the maximum amount for the CASHWAY payment method. (<a href='https://help.cashway.fr/cgu/'>More informations</a>)");?></p>
 <script type="text/javascript">
   $('p_method_cashway').disable();

--- a/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
+++ b/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
@@ -32,8 +32,12 @@ $_code=$this->getMethodCode();
  		$('p_method_cashway').disable();
 //]]>
 </script>
+<?php elseif(!$this->checkOrderAmount($this->helper('checkout/cart')->getQuote()->getGrandTotal())):?>
+<p><?php echo $this->__("Your order's amount exceeds the maximum amount for the CASHWAY payment method.");?> (<a href="https://help.cashway.fr/cgu/">More informations</a>)</p>
+<script type="text/javascript">
+  $('p_method_cashway').disable();
+</script>
 <?php else: ?>
-
 <div id="payment_form_<?php echo $_code ?>" style="display:none;">
 	<h4>Les points de paiement présents autour de votre point de livraison&nbsp;:</h4>
 	<ul class="form-list">

--- a/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
+++ b/src/magento/app/design/frontend/base/default/template/cashway/form/cashway.phtml
@@ -32,7 +32,7 @@ $_code=$this->getMethodCode();
  		$('p_method_cashway').disable();
 //]]>
 </script>
-<?php elseif(!$this->checkOrderAmount($this->helper('checkout/cart')->getQuote()->getGrandTotal())):?>
+<?php elseif(!$this->isExcessiveAmount($this->helper('checkout/cart')->getQuote()->getGrandTotal())):?>
 <p><?php echo $this->__("Your order's amount exceeds the maximum amount for the CASHWAY payment method. (<a href='https://help.cashway.fr/cgu/'>More informations</a>)");?></p>
 <script type="text/javascript">
   $('p_method_cashway').disable();

--- a/src/magento/app/locale/fr_FR/Sirateck_Cashway.csv
+++ b/src/magento/app/locale/fr_FR/Sirateck_Cashway.csv
@@ -43,3 +43,4 @@
 "Minimum Order Total","Montant minimum par commande"
 "Maximum Order Total","Montant maximum par commande"
 "Sort Order","Ordre d'affichage"
+"Your order's amount exceeds the maximum amount for the CASHWAY payment method. (<a href='https://help.cashway.fr/cgu/'>More informations</a>)","Votre commande dépasse la limite de montant pour le paiement avec Cashway. (<a href='https://help.cashway.fr/cgu/'>Plus d'informations</a>)"

--- a/src/magento/tests/spec/client_use.rb
+++ b/src/magento/tests/spec/client_use.rb
@@ -37,21 +37,30 @@ describe "Tests customer ordering products on Magento on " + ENV['TEST_SERVER'] 
       end
 
       it "selects CashWay payment" do
-        choose 'Cashway payment'
-        click_link_or_button 'Continue'
-        sleep 0.5
+        if price === 2500
+          expect(page).to have_content 'amount exceeds the maximum'
+          puts "The plugin blocks the user for an order above 1000 euros as it is supposed to."
+          visit '/index.php/checkout/cart'
+          first(:xpath, '//a[@title="Remove Item"]').click
+        else
+          choose 'Cashway payment'
+          click_link_or_button 'Continue'
+          sleep 0.5
+        end
       end
 
-      it "places order" do
-        click_link_or_button 'Place Order'
-      end
+      if price != 2500
+        it "places order" do
+          click_link_or_button 'Place Order'
+        end
 
-      it "checks confirmation page" do
-        sleep 3
-        expect(page).to have_selector('.checkout-onepage-success')
-        save_screenshot("screenshot_#{price}.png")
-        expect(page).to have_content('YOUR ORDER HAS BEEN RECEIVED.')
-        expect(page).to have_content('You will receive an order confirmation email with details of your order and a link to track its progress.')
+        it "checks confirmation page" do
+          sleep 3
+          expect(page).to have_selector('.checkout-onepage-success')
+          save_screenshot("screenshot_#{price}.png")
+          expect(page).to have_content('YOUR ORDER HAS BEEN RECEIVED.')
+          expect(page).to have_content('You will receive an order confirmation email with details of your order and a link to track its progress.')
+        end
       end
     end
   end


### PR DESCRIPTION
Le plugin contrôle maintenant si la commande ne dépasse pas 1000 euros frais inclus. Si c'est le cas, l'utilisateur ne peut choisir la méthode et un message lui explique la raison.