### PR TITLE
Mise à jour de la version minimale de PRestashop

### DIFF
--- a/src/prestashop/cashway.php
+++ b/src/prestashop/cashway.php
@@ -49,7 +49,7 @@ class CashWay extends PaymentModule
         $this->is_eu_compatible = 1;
         $this->module_key       = 'ca05dafd3cc2f9f98a086d70fe28c098';
 
-        $this->ps_versions_compliancy = array('min' => '1.5.6', 'max' => _PS_VERSION_);
+        $this->ps_versions_compliancy = array('min' => '1.5.2', 'max' => _PS_VERSION_);
 
         parent::__construct();
 


### PR DESCRIPTION
Changed the minimum version of Prestashop required from 1.5.6 to 1.5.2.